### PR TITLE
fix: sidebar element alignment oh hover

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -197,12 +197,12 @@ export function AppSidebar() {
       onMouseEnter={() => !isMobile && setOpen(true)}
       onMouseLeave={() => !isMobile && setOpen(false)}
     >
-      <SidebarHeader>
+      <SidebarHeader className="mb-2">
         <SidebarMenu>
           <SidebarMenuItem>
             <SidebarMenuButton
               size="lg"
-              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+              className="h-8 data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
               asChild
             >
               <Link href="/">
@@ -233,7 +233,6 @@ export function AppSidebar() {
 
       <SidebarContent>
         <SidebarGroup>
-          <SidebarGroupLabel>Navigation</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
               <SidebarMenuItem>


### PR DESCRIPTION
Closes #60 

- Fix the height of the _Apertúre Logo_ SidebarMenuButton to h-8 (32 px)
- Remove the _Navigation_ SidebarGroupLabel. The current sidebar is already quite intuitive and doesn't really require a header.
- Optionally added a bottom margin to create separation between the logo and actual sidebar elements.

Before:
https://github.com/user-attachments/assets/af0cec49-34b4-4e2d-85fe-ba0f176e5461

After:
https://github.com/user-attachments/assets/f8c60216-4336-43b0-9cf7-4e45f3512acb

