### PR TITLE
fix: make the setting's title act as an expand trigger

### DIFF
--- a/src/components/settings/profile-section.tsx
+++ b/src/components/settings/profile-section.tsx
@@ -245,12 +245,12 @@ export default function ProfileSection() {
     <Fragment>
       <Collapsible open={profileOpen} onOpenChange={setProfileOpen}>
         <Card className="bg-card/80 backdrop-blur">
-          <CardHeader className="flex flex-wrap items-start justify-between gap-3">
-            <CardTitle className="flex items-center gap-2 font-poppins text-lg">
-              <Settings2 className="h-5 w-5" />
-              Profile & Security
-            </CardTitle>
-            <CollapsibleTrigger asChild>
+          <CollapsibleTrigger asChild>
+            <CardHeader className="flex flex-wrap items-start justify-between gap-3 cursor-pointer">
+              <CardTitle className="flex items-center gap-2 font-poppins text-lg">
+                <Settings2 className="h-5 w-5" />
+                Profile & Security     
+              </CardTitle>
               <button
                 type="button"
                 aria-expanded={profileOpen}
@@ -264,11 +264,11 @@ export default function ProfileSection() {
                   )}
                 />
               </button>
-            </CollapsibleTrigger>
-            <CardDescription className="w-full">
-              Manage how you sign in, link devices, and refresh your avatar.
-            </CardDescription>
-          </CardHeader>
+              <CardDescription className="w-full">
+                Manage how you sign in, link devices, and refresh your avatar.
+              </CardDescription>
+            </CardHeader>
+          </CollapsibleTrigger>
           <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-up data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-down">
             <CardContent className="space-y-6">
               <div className="flex flex-col gap-4 rounded-2xl border border-border/60 bg-background/70 p-4 md:flex-row md:items-center md:justify-between">

--- a/src/components/settings/seerr-section.tsx
+++ b/src/components/settings/seerr-section.tsx
@@ -150,43 +150,43 @@ export default function SeerrSection() {
   return (
     <Collapsible open={seerrOpen} onOpenChange={setSeerrOpen}>
       <Card className="bg-card/80 backdrop-blur">
-        <CardHeader className="flex flex-wrap items-start justify-between gap-3">
-          <CardTitle className="flex items-center gap-2 font-poppins text-lg">
-            <Eye className="h-5 w-5" />
-            Seerr Integration
-            {loading && <Loader2 className="h-4 w-4 animate-spin" />}
-            {isSeerrConnected && (
-              <div className="flex items-center gap-1.5 rounded-full bg-green-500/15 px-2 py-0.5 text-[10px] font-medium text-green-500 ring-1 ring-inset ring-green-500/20">
-                <div className="h-1.5 w-1.5 rounded-full bg-green-500 animate-pulse" />
-                Connected
-              </div>
-            )}
-          </CardTitle>
-          <div className="flex items-center gap-2">
-            <Badge variant="secondary" className="text-[11px]">
-              Beta
-            </Badge>
-            <CollapsibleTrigger asChild>
-              <button
-                type="button"
-                aria-expanded={seerrOpen}
-                className="inline-flex items-center gap-1 rounded-full border border-border/60 px-3 py-1 text-xs font-semibold text-muted-foreground transition hover:text-foreground"
-              >
-                {seerrOpen ? "Hide" : "Show"}
-                <ChevronDown
-                  className={cn(
-                    "h-3.5 w-3.5 transition-transform duration-200",
-                    seerrOpen ? "rotate-180" : "rotate-0",
-                  )}
-                />
-              </button>
-            </CollapsibleTrigger>
-          </div>
-          <CardDescription className="w-full">
-            Configure your Overseerr or Jellyseerr instance to handle media
-            requests directly.
-          </CardDescription>
-        </CardHeader>
+        <CollapsibleTrigger asChild>
+          <CardHeader className="flex flex-wrap items-start justify-between gap-3 cursor-pointer">
+            <CardTitle className="flex items-center gap-2 font-poppins text-lg">
+              <Eye className="h-5 w-5" />
+              Seerr Integration
+              {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+              {isSeerrConnected && (
+                <div className="flex items-center gap-1.5 rounded-full bg-green-500/15 px-2 py-0.5 text-[10px] font-medium text-green-500 ring-1 ring-inset ring-green-500/20">
+                  <div className="h-1.5 w-1.5 rounded-full bg-green-500 animate-pulse" />
+                  Connected
+                </div>
+              )}
+            </CardTitle>
+            <div className="flex items-center gap-2">
+              <Badge variant="secondary" className="text-[11px]">
+                Beta
+              </Badge>
+                <button
+                  type="button"
+                  aria-expanded={seerrOpen}
+                  className="inline-flex items-center gap-1 rounded-full border border-border/60 px-3 py-1 text-xs font-semibold text-muted-foreground transition hover:text-foreground"
+                >
+                  {seerrOpen ? "Hide" : "Show"}
+                  <ChevronDown
+                    className={cn(
+                      "h-3.5 w-3.5 transition-transform duration-200",
+                      seerrOpen ? "rotate-180" : "rotate-0",
+                    )}
+                  />
+                </button>
+            </div>
+            <CardDescription className="w-full">
+              Configure your Overseerr or Jellyseerr instance to handle media
+              requests directly.
+            </CardDescription>
+          </CardHeader>
+        </CollapsibleTrigger>
         <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-up data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-down">
           <CardContent className="space-y-6">
             {loading ? (

--- a/src/components/settings/theme-section.tsx
+++ b/src/components/settings/theme-section.tsx
@@ -125,37 +125,37 @@ export default function ThemeSection() {
   return (
     <Collapsible open={themesOpen} onOpenChange={setThemesOpen}>
       <Card className="bg-card/80 backdrop-blur">
-        <CardHeader className="flex flex-wrap items-start justify-between gap-3">
-          <CardTitle className="flex items-center gap-2 font-poppins text-lg">
-            <Palette className="h-5 w-5" />
-            Themes
-          </CardTitle>
-          <div className="flex items-center gap-2">
-            <Badge variant="secondary" className="text-[11px]">
-              {THEME_VARIANTS.variants.length} variant
-              {THEME_VARIANTS.variants.length !== 1 ? "s" : ""}
-            </Badge>
-            <CollapsibleTrigger asChild>
-              <button
-                type="button"
-                aria-expanded={themesOpen}
-                className="inline-flex items-center gap-1 rounded-full border border-border/60 px-3 py-1 text-xs font-semibold text-muted-foreground transition hover:text-foreground"
-              >
-                {themesOpen ? "Hide" : "Show"}
-                <ChevronDown
-                  className={cn(
-                    "h-3.5 w-3.5 transition-transform duration-200",
-                    themesOpen ? "rotate-180" : "rotate-0",
-                  )}
-                />
-              </button>
-            </CollapsibleTrigger>
-          </div>
-          <CardDescription className="w-full">
-            Explore the palette families that power the dashboard theming system
-            and apply any variant instantly.
-          </CardDescription>
-        </CardHeader>
+        <CollapsibleTrigger asChild>
+          <CardHeader className="flex flex-wrap items-start justify-between gap-3 cursor-pointer">
+            <CardTitle className="flex items-center gap-2 font-poppins text-lg">
+              <Palette className="h-5 w-5" />
+              Themes
+            </CardTitle>
+            <div className="flex items-center gap-2">
+              <Badge variant="secondary" className="text-[11px]">
+                {THEME_VARIANTS.variants.length} variant
+                {THEME_VARIANTS.variants.length !== 1 ? "s" : ""}
+              </Badge>
+                <button
+                  type="button"
+                  aria-expanded={themesOpen}
+                  className="inline-flex items-center gap-1 rounded-full border border-border/60 px-3 py-1 text-xs font-semibold text-muted-foreground transition hover:text-foreground"
+                >
+                  {themesOpen ? "Hide" : "Show"}
+                  <ChevronDown
+                    className={cn(
+                      "h-3.5 w-3.5 transition-transform duration-200",
+                      themesOpen ? "rotate-180" : "rotate-0",
+                    )}
+                  />
+                </button>
+            </div>
+            <CardDescription className="w-full">
+              Explore the palette families that power the dashboard theming system
+              and apply any variant instantly.
+            </CardDescription>
+          </CardHeader>
+        </CollapsibleTrigger>
         <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-up data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-down">
           <CardContent className="space-y-4">
             <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">

--- a/src/components/settings/user-preference-section.tsx
+++ b/src/components/settings/user-preference-section.tsx
@@ -47,30 +47,30 @@ export default function UserPreferenceSection() {
   return (
     <Collapsible open={preferencesOpen} onOpenChange={setPreferencesOpen}>
       <Card className="bg-card/80 backdrop-blur">
-        <CardHeader className="flex flex-wrap items-start justify-between gap-3">
-          <CardTitle className="flex items-center gap-2 font-poppins text-lg">
-            <Sliders className="h-5 w-5" />
-            User Preferences
-          </CardTitle>
-          <CollapsibleTrigger asChild>
-            <button
-              type="button"
-              aria-expanded={preferencesOpen}
-              className="inline-flex items-center gap-1 rounded-full border border-border/60 px-3 py-1 text-xs font-semibold text-muted-foreground transition hover:text-foreground"
-            >
-              {preferencesOpen ? "Hide" : "Show"}
-              <ChevronDown
-                className={cn(
-                  "h-3.5 w-3.5 transition-transform duration-200",
-                  preferencesOpen ? "rotate-180" : "rotate-0",
-                )}
-              />
-            </button>
-          </CollapsibleTrigger>
-          <CardDescription className="w-full">
-            Customize your playback and interface experience.
-          </CardDescription>
-        </CardHeader>
+        <CollapsibleTrigger asChild>
+          <CardHeader className="flex flex-wrap items-start justify-between gap-3 cursor-pointer">
+            <CardTitle className="flex items-center gap-2 font-poppins text-lg">
+              <Sliders className="h-5 w-5" />
+              User Preferences
+            </CardTitle>
+              <button
+                type="button"
+                aria-expanded={preferencesOpen}
+                className="inline-flex items-center gap-1 rounded-full border border-border/60 px-3 py-1 text-xs font-semibold text-muted-foreground transition hover:text-foreground"
+              >
+                {preferencesOpen ? "Hide" : "Show"}
+                <ChevronDown
+                  className={cn(
+                    "h-3.5 w-3.5 transition-transform duration-200",
+                    preferencesOpen ? "rotate-180" : "rotate-0",
+                  )}
+                />
+              </button>
+            <CardDescription className="w-full">
+              Customize your playback and interface experience.
+            </CardDescription>
+          </CardHeader>
+        </CollapsibleTrigger>
         <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-up data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-down">
           <CardContent className="space-y-4">
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">


### PR DESCRIPTION
Closes #63 

- Make the entire setting's _CardHeader_ act as the collapse trigger instead of just the show/hide button


https://github.com/user-attachments/assets/1327a7fd-86e8-4bbb-88a1-119a8473c286

