### PR TITLE
feat: persist home state across navigation for 60 seconds

### DIFF
--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -13,7 +13,7 @@ import { AuroraBackground } from "@/src/components/aurora-background";
 import { useEffect, useState } from "react";
 import { useAtom } from "jotai";
 import {
-  homeLastFetchTimeAtom,
+  homeLastVisitedTimeAtom,
   homeServerUrlAtom,
   homeUserAtom,
   homeResumeItemsAtom,
@@ -32,15 +32,16 @@ export default function Home() {
   const [resumeItems, setResumeItems] = useAtom(homeResumeItemsAtom);
   const [nextupItems, setNextupItems] = useAtom(homeNextupItemsAtom);
   const [libraries, setLibraries] = useAtom(homeLibrariesAtom);
-  const [lastFetchTime, setLastFetchTime] = useAtom(homeLastFetchTimeAtom);
+  const [lastVisitedTime, setLastVisitedTime] = useAtom(homeLastVisitedTimeAtom);
 
   const [authError, setAuthError] = useState<any | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
 
   useEffect(() => {
     const now = Date.now();
-    // Only refetch if 60 seconds have passed since last fetch (in this session)
-    if (now - lastFetchTime < 60000) {
+    // Only refetch if 60 seconds have passed since the page was last visited
+    if (now - lastVisitedTime < 60000) {
+      setLastVisitedTime(Date.now());
       setLoading(false);
       return;
     }
@@ -80,7 +81,7 @@ export default function Home() {
         );
 
         setLibraries(libraryData);
-        setLastFetchTime(Date.now());
+        setLastVisitedTime(Date.now());
       } catch (error: any) {
         console.error("Failed to load data:", error);
 

--- a/src/components/hero/hero-section.tsx
+++ b/src/components/hero/hero-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
-import { BaseItemDto } from "@jellyfin/sdk/lib/generated-client/models/base-item-dto";
+import { useAtom } from "jotai";
+import { heroItemsAtom, heroLastVisitedTimeAtom } from "@/src/lib/atoms";
 import { fetchHeroItems } from "../../actions/media";
 import { HeroCarousel } from "./hero-carousel";
 import { Skeleton } from "../ui/skeleton";
@@ -10,22 +11,30 @@ interface HeroSectionProps {
 }
 
 export function HeroSection({ serverUrl }: HeroSectionProps) {
-  const [items, setItems] = useState<BaseItemDto[]>([]);
+  const [items, setItems] = useAtom(heroItemsAtom);
+  const [lastVisitedTime, setLastVisitedTime] = useAtom(heroLastVisitedTimeAtom);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    if (!serverUrl) return;
+    const now = Date.now();
+    // Only refetch if 60 seconds have passed since the page was last visited
+    if (now - lastVisitedTime < 60000) {
+      setLastVisitedTime(Date.now());
+      setLoading(false);
+      return;
+    }
     async function loadHeroItems() {
-      if (!serverUrl) return;
       try {
         const heroItems = await fetchHeroItems();
         setItems(heroItems);
+        setLastVisitedTime(Date.now());
       } catch (error) {
         console.error("Error loading hero items", error);
       } finally {
         setLoading(false);
       }
     }
-
     loadHeroItems();
   }, [serverUrl]);
 

--- a/src/lib/atoms.ts
+++ b/src/lib/atoms.ts
@@ -58,4 +58,6 @@ export const homeLibrariesAtom = atom<
     items: BaseItemDto[];
   }[]
 >([]);
-export const homeLastFetchTimeAtom = atom(0); // Last fetch time for homepage
+export const homeLastVisitedTimeAtom = atom(0); // Last visited time for homepage
+export const heroItemsAtom = atom<BaseItemDto[]>([]);
+export const heroLastVisitedTimeAtom = atom(0); // Last visited time for hero section


### PR DESCRIPTION
Closes #65 

-  replace useState with jotai useAtom, to persist homescreen (along with herosection) data for the session.
- add a `60`second **retention** window so the home data is preserved across navigations as long as the user revisits the homepage within that time. A browser reload still triggers a fresh fetch of the home data.



https://github.com/user-attachments/assets/e6497c78-7ecc-446f-9d6f-d0729f0d4b77



