### PR TITLE
feat: add OpenSubtitles subtitle search and management

### DIFF
--- a/app/(main)/settings/page.tsx
+++ b/app/(main)/settings/page.tsx
@@ -2,6 +2,7 @@ import { AuroraBackground } from "@/src/components/aurora-background";
 import { SearchBar } from "@/src/components/search-component";
 import { Settings2 } from "lucide-react";
 import SeerrSection from "@/src/components/settings/seerr-section";
+import OpenSubtitlesSection from "@/src/components/settings/opensubtitles-section";
 import ProfileSection from "@/src/components/settings/profile-section";
 import ThemeSection from "@/src/components/settings/theme-section";
 import UserPreferenceSection from "@/src/components/settings/user-preference-section";
@@ -28,6 +29,7 @@ export default function SettingsPage() {
         <div className="grid gap-6">
           <ProfileSection />
           <SeerrSection />
+          <OpenSubtitlesSection />
           <UserPreferenceSection />
           <ThemeSection />
         </div>

--- a/app/api/subtitles/download/route.ts
+++ b/app/api/subtitles/download/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getOpenSubtitlesConfig } from "@/src/actions/store/server-actions";
+import {
+  downloadSubtitle,
+  OpenSubtitlesError,
+} from "@/src/lib/opensubtitles";
+
+export async function POST(req: NextRequest) {
+  const config = await getOpenSubtitlesConfig();
+  if (!config?.apiKey || !config?.username || !config?.password) {
+    return NextResponse.json(
+      {
+        message:
+          "OpenSubtitles is not configured. Add your credentials in Settings.",
+      },
+      { status: 400 },
+    );
+  }
+
+  let body: { fileId?: number };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ message: "Invalid request body" }, { status: 400 });
+  }
+
+  const fileId = Number(body.fileId);
+  if (!Number.isFinite(fileId) || fileId <= 0) {
+    return NextResponse.json(
+      { message: "A valid fileId is required" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await downloadSubtitle(config, fileId);
+    return NextResponse.json(result);
+  } catch (error) {
+    const status = error instanceof OpenSubtitlesError ? error.status : 500;
+    const message =
+      error instanceof Error ? error.message : "Subtitle download failed";
+    return NextResponse.json({ message }, { status });
+  }
+}

--- a/app/api/subtitles/search/route.ts
+++ b/app/api/subtitles/search/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getOpenSubtitlesConfig } from "@/src/actions/store/server-actions";
+import {
+  searchSubtitles,
+  OpenSubtitlesError,
+} from "@/src/lib/opensubtitles";
+
+export async function GET(req: NextRequest) {
+  const config = await getOpenSubtitlesConfig();
+  if (!config?.apiKey || !config?.username || !config?.password) {
+    return NextResponse.json(
+      {
+        message:
+          "OpenSubtitles is not configured. Add your credentials in Settings.",
+      },
+      { status: 400 },
+    );
+  }
+
+  const { searchParams } = new URL(req.url);
+  const imdbId = searchParams.get("imdbId") || undefined;
+  const tmdbId = searchParams.get("tmdbId") || undefined;
+  const query = searchParams.get("query") || undefined;
+  const languages =
+    searchParams.get("languages") || config.languages || "en";
+  const year = searchParams.get("year") || undefined;
+  const seasonNumber = searchParams.get("season") || undefined;
+  const episodeNumber = searchParams.get("episode") || undefined;
+
+  if (!imdbId && !tmdbId && !query) {
+    return NextResponse.json(
+      { message: "Provide an imdbId, tmdbId, or query to search." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const results = await searchSubtitles(config, {
+      imdbId,
+      tmdbId,
+      query,
+      languages,
+      year,
+      seasonNumber,
+      episodeNumber,
+    });
+    return NextResponse.json({ results });
+  } catch (error) {
+    const status = error instanceof OpenSubtitlesError ? error.status : 500;
+    const message =
+      error instanceof Error ? error.message : "Subtitle search failed";
+    return NextResponse.json({ message }, { status });
+  }
+}

--- a/app/api/subtitles/test/route.ts
+++ b/app/api/subtitles/test/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { testConnection, OpenSubtitlesError } from "@/src/lib/opensubtitles";
+
+// Validates the credentials the user just typed (sent in the body) BEFORE they
+// are saved, mirroring the Seerr "test-connection" flow.
+export async function POST(req: NextRequest) {
+  let body: { apiKey?: string; username?: string; password?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ message: "Invalid request body" }, { status: 400 });
+  }
+
+  const { apiKey, username, password } = body;
+  if (!apiKey || !username || !password) {
+    return NextResponse.json(
+      { message: "API key, username and password are all required" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const quota = await testConnection({ apiKey, username, password });
+    return NextResponse.json({ success: true, quota });
+  } catch (error) {
+    const status = error instanceof OpenSubtitlesError ? error.status : 500;
+    const message =
+      error instanceof Error ? error.message : "Connection failed";
+    return NextResponse.json({ success: false, message }, { status });
+  }
+}

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -119,6 +119,15 @@ export {
   updateTaskTriggers,
 } from "./scheduled-tasks";
 export { fetchActivityLogEntries } from "./activity-log";
+export {
+  getInstalledSubtitles,
+  uploadSubtitleToJellyfin,
+  deleteJellyfinSubtitle,
+} from "./subtitles-search";
+export type {
+  InstalledSubtitle,
+  UploadSubtitleInput,
+} from "./subtitles-search";
 
 // Types
 export type {

--- a/src/actions/media.ts
+++ b/src/actions/media.ts
@@ -217,6 +217,7 @@ export async function fetchMediaDetails(
         ItemFields.Studios,
         ItemFields.Trickplay,
         ItemFields.Chapters,
+        ItemFields.ProviderIds,
       ],
     });
     return data.Items?.[0] ?? null;

--- a/src/actions/store/server-actions.ts
+++ b/src/actions/store/server-actions.ts
@@ -26,6 +26,14 @@ export type SeerrAuthData =
       password: string;
     };
 
+export interface OpenSubtitlesConfig {
+  apiKey: string;
+  username: string;
+  password: string;
+  // Comma separated ISO 639 language codes preferred for searches, e.g. "en,es"
+  languages?: string;
+}
+
 // --- StoreServerURL actions ---
 const SERVER_URL_KEY = "jellyfin-server-url";
 
@@ -137,4 +145,50 @@ export async function getSeerrData(): Promise<SeerrAuthData | null> {
 
 export async function removeSeerrData() {
   (await cookies()).delete(SEERR_DATA_KEY);
+}
+
+// --- StoreOpenSubtitlesData actions ---
+// Unlike the other config cookies above, this one holds an API key + password
+// for a third-party service, so it is stored httpOnly: the value is only ever
+// read server-side (the /api/subtitles/* route handlers) and never exposed to
+// client-side JavaScript via document.cookie.
+const OPENSUBTITLES_DATA_KEY = "opensubtitles-config";
+
+export async function setOpenSubtitlesConfig(value: OpenSubtitlesConfig) {
+  (await cookies()).set(OPENSUBTITLES_DATA_KEY, JSON.stringify(value), {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+  });
+}
+
+export async function getOpenSubtitlesConfig(): Promise<OpenSubtitlesConfig | null> {
+  const cookieStore = await cookies();
+  const val = cookieStore.get(OPENSUBTITLES_DATA_KEY);
+  if (!val || !val.value) return null;
+
+  try {
+    return JSON.parse(val.value) as OpenSubtitlesConfig;
+  } catch {
+    return null;
+  }
+}
+
+export async function removeOpenSubtitlesConfig() {
+  (await cookies()).delete(OPENSUBTITLES_DATA_KEY);
+}
+
+// Returns just enough for the settings UI to render its "configured" state
+// without pulling the secret values into client memory.
+export async function getOpenSubtitlesStatus(): Promise<{
+  configured: boolean;
+  username: string;
+  languages: string;
+}> {
+  const config = await getOpenSubtitlesConfig();
+  return {
+    configured: !!(config?.apiKey && config?.username && config?.password),
+    username: config?.username ?? "",
+    languages: config?.languages ?? "en",
+  };
 }

--- a/src/actions/store/store-opensubtitles-data.ts
+++ b/src/actions/store/store-opensubtitles-data.ts
@@ -1,0 +1,26 @@
+import {
+  OpenSubtitlesConfig,
+  setOpenSubtitlesConfig,
+  getOpenSubtitlesConfig,
+  removeOpenSubtitlesConfig,
+  getOpenSubtitlesStatus,
+} from "./server-actions";
+
+export class StoreOpenSubtitlesData {
+  static async set(value: OpenSubtitlesConfig) {
+    return setOpenSubtitlesConfig(value);
+  }
+
+  static async get(): Promise<OpenSubtitlesConfig | null> {
+    return getOpenSubtitlesConfig();
+  }
+
+  static async remove() {
+    return removeOpenSubtitlesConfig();
+  }
+
+  // Safe to call from the client: never returns the apiKey/password.
+  static async status() {
+    return getOpenSubtitlesStatus();
+  }
+}

--- a/src/actions/subtitles-search.ts
+++ b/src/actions/subtitles-search.ts
@@ -1,0 +1,134 @@
+"use server";
+
+import { UserLibraryApi } from "@jellyfin/sdk/lib/generated-client/api/user-library-api";
+import { createJellyfinInstance } from "@/src/lib/utils";
+import { getAuthData } from "./utils";
+
+export interface InstalledSubtitle {
+  index: number;
+  language: string;
+  displayTitle: string;
+  codec: string;
+  isExternal: boolean;
+  isForced: boolean;
+  isDefault: boolean;
+  isHearingImpaired: boolean;
+  title: string;
+  path: string | null;
+}
+
+// Lists the subtitle streams Jellyfin currently knows about for a media source,
+// with enough detail to show status and decide what can be deleted (only
+// external/sidecar subtitles can be removed; embedded ones cannot).
+export async function getInstalledSubtitles(
+  itemId: string,
+  mediaSourceId: string,
+): Promise<InstalledSubtitle[]> {
+  const { serverUrl, user } = await getAuthData();
+  if (!user.AccessToken) throw new Error("No access token found");
+
+  const jellyfinInstance = createJellyfinInstance();
+  const api = jellyfinInstance.createApi(serverUrl);
+  api.accessToken = user.AccessToken;
+
+  const userLibraryApi = new UserLibraryApi(api.configuration);
+  const { data: item } = await userLibraryApi.getItem({
+    userId: user.Id,
+    itemId,
+  });
+
+  const mediaSource =
+    item.MediaSources?.find((ms) => ms.Id === mediaSourceId) ||
+    item.MediaSources?.[0];
+
+  const streams = mediaSource?.MediaStreams ?? [];
+  return streams
+    .filter((s) => s.Type === "Subtitle")
+    .map((s) => ({
+      index: s.Index ?? -1,
+      language: s.Language || "",
+      displayTitle: s.DisplayTitle || s.Title || s.Language || "Subtitle",
+      codec: s.Codec || "",
+      isExternal: !!s.IsExternal,
+      isForced: !!s.IsForced,
+      isDefault: !!s.IsDefault,
+      isHearingImpaired: !!(s as { IsHearingImpaired?: boolean })
+        .IsHearingImpaired,
+      title: s.Title || "",
+      path: (s as { Path?: string }).Path || null,
+    }));
+}
+
+export interface UploadSubtitleInput {
+  language: string; // ISO 639 code, e.g. "en"
+  format: string; // "srt", "ass", ...
+  contentBase64: string;
+  isForced?: boolean;
+  isHearingImpaired?: boolean;
+}
+
+// Hands a subtitle file to Jellyfin's own upload endpoint. Jellyfin writes it
+// as an external sidecar next to the media file (in your existing media path)
+// and re-indexes it as a selectable track. This is why aperture never needs
+// filesystem access to the media volume.
+export async function uploadSubtitleToJellyfin(
+  itemId: string,
+  input: UploadSubtitleInput,
+): Promise<{ success: boolean; message?: string }> {
+  const { serverUrl, user } = await getAuthData();
+  if (!user.AccessToken) throw new Error("No access token found");
+
+  const url = `${serverUrl.replace(/\/+$/, "")}/Videos/${itemId}/Subtitles`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `MediaBrowser Token="${user.AccessToken}"`,
+    },
+    body: JSON.stringify({
+      Language: input.language,
+      Format: input.format,
+      IsForced: input.isForced ?? false,
+      IsHearingImpaired: input.isHearingImpaired ?? false,
+      Data: input.contentBase64,
+    }),
+  });
+
+  if (!res.ok) {
+    let message = `Upload failed: ${res.status} ${res.statusText}`;
+    try {
+      const text = await res.text();
+      if (text) message = `${message} – ${text.slice(0, 200)}`;
+    } catch {}
+    return { success: false, message };
+  }
+
+  return { success: true };
+}
+
+// Removes an external subtitle by its stream index. Embedded subtitle streams
+// cannot be deleted (they are part of the container) and will error.
+export async function deleteJellyfinSubtitle(
+  itemId: string,
+  index: number,
+): Promise<{ success: boolean; message?: string }> {
+  const { serverUrl, user } = await getAuthData();
+  if (!user.AccessToken) throw new Error("No access token found");
+
+  const url = `${serverUrl.replace(/\/+$/, "")}/Videos/${itemId}/Subtitles/${index}`;
+  const res = await fetch(url, {
+    method: "DELETE",
+    headers: {
+      Authorization: `MediaBrowser Token="${user.AccessToken}"`,
+    },
+  });
+
+  if (!res.ok) {
+    return {
+      success: false,
+      message: `Delete failed: ${res.status} ${res.statusText}`,
+    };
+  }
+
+  return { success: true };
+}

--- a/src/components/media-actions.tsx
+++ b/src/components/media-actions.tsx
@@ -18,6 +18,7 @@ import {
 } from "../components/ui/dialog";
 import { MediaInfoDialog } from "../components/media-info-dialog";
 import { ImageEditorDialog } from "../components/image-editor-dialog";
+import { SubtitleManagerDialog } from "../components/subtitles/subtitle-manager-dialog";
 import {
   Info,
   Download,
@@ -543,6 +544,12 @@ export function MediaActions({
               <MediaInfoDialog mediaSource={selectedVersion} />
             </DialogContent>
           </Dialog>
+
+          <SubtitleManagerDialog
+            media={media}
+            mediaSource={selectedVersion}
+            triggerClassName="flex-1 sm:flex-none sm:h-9 sm:w-9 sm:px-0 sm:gap-0"
+          />
 
           {userPolicy?.IsAdministrator && (
             <ImageEditorDialog

--- a/src/components/settings/opensubtitles-section.tsx
+++ b/src/components/settings/opensubtitles-section.tsx
@@ -1,0 +1,270 @@
+"use client";
+import {
+  Captions,
+  ChevronDown,
+  Key,
+  Loader2,
+  Save,
+  User,
+  Languages,
+} from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/src/components/ui/card";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/src/components/ui/collapsible";
+import { Badge } from "@/src/components/ui/badge";
+import { cn } from "@/src/lib/utils";
+import { Label } from "@/src/components/ui/label";
+import { Input } from "@/src/components/ui/input";
+import { Button } from "@/src/components/ui/button";
+import { useCallback, useEffect, useState } from "react";
+import { StoreOpenSubtitlesData } from "@/src/actions/store/store-opensubtitles-data";
+import { toast } from "sonner";
+
+export default function OpenSubtitlesSection() {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [configured, setConfigured] = useState(false);
+  const [savedUsername, setSavedUsername] = useState("");
+
+  // Form state
+  const [apiKey, setApiKey] = useState("");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [languages, setLanguages] = useState("en");
+
+  const loadStatus = useCallback(async () => {
+    try {
+      const status = await StoreOpenSubtitlesData.status();
+      setConfigured(status.configured);
+      setSavedUsername(status.username);
+      setLanguages(status.languages || "en");
+    } catch (error) {
+      console.error("Failed to load OpenSubtitles status", error);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadStatus();
+  }, [loadStatus]);
+
+  const handleDisconnect = async () => {
+    await StoreOpenSubtitlesData.remove();
+    setApiKey("");
+    setUsername("");
+    setPassword("");
+    setConfigured(false);
+    setSavedUsername("");
+    toast.success("Disconnected OpenSubtitles");
+  };
+
+  const handleConnect = async () => {
+    if (!apiKey || !username || !password) {
+      toast.error("API key, username and password are all required");
+      return;
+    }
+
+    setLoading(true);
+    const toastId = toast.loading("Testing OpenSubtitles connection…");
+    try {
+      const res = await fetch("/api/subtitles/test", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ apiKey, username, password }),
+      });
+      const data = await res.json();
+
+      if (!res.ok || !data.success) {
+        toast.error(data?.message || "Connection failed", { id: toastId });
+        return;
+      }
+
+      await StoreOpenSubtitlesData.set({
+        apiKey,
+        username,
+        password,
+        languages: languages.trim() || "en",
+      });
+
+      const remaining = data.quota?.remaining;
+      const allowed = data.quota?.allowed;
+      const quotaMsg =
+        typeof remaining === "number" && typeof allowed === "number"
+          ? ` — ${remaining}/${allowed} downloads left today`
+          : "";
+      toast.success(`OpenSubtitles connected${quotaMsg}`, { id: toastId });
+      setConfigured(true);
+      setSavedUsername(username);
+    } catch (error) {
+      console.error(error);
+      toast.error("An unexpected error occurred", { id: toastId });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <Card className="bg-card/80 backdrop-blur">
+        <CollapsibleTrigger asChild>
+          <CardHeader className="flex flex-wrap items-start justify-between gap-3 cursor-pointer">
+            <CardTitle className="flex items-center gap-2 font-poppins text-lg">
+              <Captions className="h-5 w-5" />
+              Subtitle Search (OpenSubtitles)
+              {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+              {configured && (
+                <div className="flex items-center gap-1.5 rounded-full bg-green-500/15 px-2 py-0.5 text-[10px] font-medium text-green-500 ring-1 ring-inset ring-green-500/20">
+                  <div className="h-1.5 w-1.5 rounded-full bg-green-500 animate-pulse" />
+                  Connected
+                </div>
+              )}
+            </CardTitle>
+            <button
+              type="button"
+              aria-expanded={open}
+              className="inline-flex items-center gap-1 rounded-full border border-border/60 px-3 py-1 text-xs font-semibold text-muted-foreground transition hover:text-foreground"
+            >
+              {open ? "Hide" : "Show"}
+              <ChevronDown
+                className={cn(
+                  "h-3.5 w-3.5 transition-transform duration-200",
+                  open ? "rotate-180" : "rotate-0",
+                )}
+              />
+            </button>
+            <CardDescription className="w-full">
+              Connect your OpenSubtitles.com account to search and download
+              subtitles directly from a title&apos;s page. Downloads are saved
+              into your media library through Jellyfin.
+            </CardDescription>
+          </CardHeader>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0">
+          <CardContent className="space-y-6">
+            {loading ? (
+              <div className="flex items-center justify-center py-4 text-muted-foreground">
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Loading…
+              </div>
+            ) : configured ? (
+              <div className="rounded-lg border border-green-500/20 bg-green-500/5 p-4">
+                <div className="flex items-center gap-3">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-green-500/10">
+                    <Captions className="h-5 w-5 text-green-500" />
+                  </div>
+                  <div className="flex-1">
+                    <h4 className="text-sm font-medium text-foreground">
+                      Connected to OpenSubtitles
+                    </h4>
+                    <p className="text-xs text-muted-foreground break-all">
+                      {savedUsername} · languages: {languages}
+                    </p>
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    onClick={handleDisconnect}
+                  >
+                    Disconnect
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <>
+                <div className="space-y-2">
+                  <Label htmlFor="os-api-key">API Key</Label>
+                  <div className="relative">
+                    <Key className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
+                    <Input
+                      id="os-api-key"
+                      type="password"
+                      placeholder="Your API key from opensubtitles.com → Consumers"
+                      className="pl-9 bg-background/50"
+                      value={apiKey}
+                      onChange={(e) => setApiKey(e.target.value)}
+                    />
+                  </div>
+                  <p className="text-[11px] text-muted-foreground">
+                    Create a free API key under your account&apos;s{" "}
+                    <span className="font-medium">API Consumers</span> section at
+                    opensubtitles.com.
+                  </p>
+                </div>
+
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="os-username">Username</Label>
+                    <div className="relative">
+                      <User className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
+                      <Input
+                        id="os-username"
+                        placeholder="OpenSubtitles username"
+                        className="pl-9 bg-background/50"
+                        value={username}
+                        onChange={(e) => setUsername(e.target.value)}
+                      />
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="os-password">Password</Label>
+                    <Input
+                      id="os-password"
+                      type="password"
+                      placeholder="Password"
+                      className="bg-background/50"
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                    />
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="os-langs">Preferred languages</Label>
+                  <div className="relative">
+                    <Languages className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
+                    <Input
+                      id="os-langs"
+                      placeholder="en,es,pt-br"
+                      className="pl-9 bg-background/50"
+                      value={languages}
+                      onChange={(e) => setLanguages(e.target.value)}
+                    />
+                  </div>
+                  <p className="text-[11px] text-muted-foreground">
+                    Comma-separated ISO codes used as the default for searches.
+                  </p>
+                </div>
+
+                <div className="flex justify-end pt-2">
+                  <Button
+                    size="sm"
+                    className="w-full gap-2 sm:w-auto"
+                    onClick={handleConnect}
+                    disabled={loading}
+                  >
+                    {loading ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Save className="h-4 w-4" />
+                    )}
+                    Connect
+                  </Button>
+                </div>
+              </>
+            )}
+          </CardContent>
+        </CollapsibleContent>
+      </Card>
+    </Collapsible>
+  );
+}

--- a/src/components/subtitles/subtitle-manager-dialog.tsx
+++ b/src/components/subtitles/subtitle-manager-dialog.tsx
@@ -1,0 +1,685 @@
+"use client";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "../ui/dialog";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "../ui/tabs";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { Label } from "../ui/label";
+import { Badge } from "../ui/badge";
+import { ScrollArea } from "../ui/scroll-area";
+import { Flag } from "../ui/flag";
+import {
+  Captions,
+  Search,
+  Upload,
+  Trash2,
+  Download,
+  Loader2,
+  CheckCircle2,
+  Film,
+  AlertTriangle,
+} from "lucide-react";
+import { toast } from "sonner";
+import { JellyfinItem, MediaSourceInfo, MediaStream } from "../../types/jellyfin";
+import {
+  getInstalledSubtitles,
+  uploadSubtitleToJellyfin,
+  deleteJellyfinSubtitle,
+  type InstalledSubtitle,
+} from "../../actions";
+import { formatRuntime } from "../../lib/utils";
+
+interface SearchResult {
+  fileId: number | null;
+  fileName: string;
+  language: string;
+  release: string;
+  fps: number | null;
+  downloadCount: number;
+  ratings: number;
+  fromTrusted: boolean;
+  hearingImpaired: boolean;
+  hd: boolean;
+  aiTranslated: boolean;
+  machineTranslated: boolean;
+  uploadDate: string | null;
+}
+
+interface SubtitleManagerDialogProps {
+  media?: JellyfinItem;
+  mediaSource?: MediaSourceInfo | null;
+  triggerClassName?: string;
+  triggerLabelClassName?: string;
+}
+
+function baseName(path?: string | null): string {
+  if (!path) return "";
+  return path.split(/[\\/]/).pop() || path;
+}
+
+export function SubtitleManagerDialog({
+  media,
+  mediaSource,
+  triggerClassName,
+  triggerLabelClassName,
+}: SubtitleManagerDialogProps) {
+  const [open, setOpen] = useState(false);
+
+  if (!media?.Id) return null;
+  const itemId = media.Id;
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm" className={triggerClassName}>
+          <Captions className="h-4 w-4" />
+          <span className={triggerLabelClassName ?? "ml-2 text-sm sm:hidden"}>
+            Subtitles
+          </span>
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[85vh] w-[calc(100%-2rem)] !max-w-4xl overflow-y-auto dark:bg-background/30 backdrop-blur-md z-9999999999">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Captions className="h-5 w-5" />
+            Subtitles
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            Search, upload and manage subtitles for this title.
+          </DialogDescription>
+        </DialogHeader>
+        {open && (
+          <SubtitleManagerContent
+            media={media}
+            itemId={itemId}
+            mediaSource={mediaSource ?? null}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function SubtitleManagerContent({
+  media,
+  itemId,
+  mediaSource,
+}: {
+  media: JellyfinItem;
+  itemId: string;
+  mediaSource: MediaSourceInfo | null;
+}) {
+  const videoStream = mediaSource?.MediaStreams?.find(
+    (s: MediaStream) => s.Type === "Video",
+  );
+  const fileFps =
+    videoStream?.AverageFrameRate || videoStream?.RealFrameRate || null;
+  const fileName =
+    baseName(mediaSource?.Path) || mediaSource?.Name || media.Name || "";
+  const runtime = formatRuntime(media.RunTimeTicks ?? undefined);
+  const imdbId = (media.ProviderIds as Record<string, string> | undefined)?.Imdb;
+  const tmdbId = (media.ProviderIds as Record<string, string> | undefined)?.Tmdb;
+
+  const [installed, setInstalled] = useState<InstalledSubtitle[]>([]);
+  const [loadingInstalled, setLoadingInstalled] = useState(true);
+
+  const refreshInstalled = useCallback(async () => {
+    if (!mediaSource?.Id) {
+      setInstalled([]);
+      setLoadingInstalled(false);
+      return;
+    }
+    try {
+      const subs = await getInstalledSubtitles(itemId, mediaSource.Id);
+      setInstalled(subs);
+    } catch (e) {
+      console.error("Failed to load installed subtitles", e);
+    } finally {
+      setLoadingInstalled(false);
+    }
+  }, [itemId, mediaSource?.Id]);
+
+  useEffect(() => {
+    refreshInstalled();
+  }, [refreshInstalled]);
+
+  return (
+    <div className="space-y-4">
+      {/* Your file — for matching search results */}
+      <div className="rounded-lg border border-border/50 bg-background/40 p-3 text-xs">
+        <div className="flex items-center gap-2 font-medium text-foreground">
+          <Film className="h-4 w-4 text-primary" />
+          <span className="truncate" title={fileName}>
+            {fileName || "Unknown file"}
+          </span>
+        </div>
+        <div className="mt-1.5 flex flex-wrap gap-2 text-muted-foreground">
+          {fileFps ? <Badge variant="secondary">{fileFps.toFixed(3)} fps</Badge> : null}
+          {runtime ? <Badge variant="secondary">{runtime}</Badge> : null}
+          {mediaSource?.Container ? (
+            <Badge variant="secondary">{mediaSource.Container}</Badge>
+          ) : null}
+        </div>
+      </div>
+
+      <Tabs defaultValue="search" className="w-full">
+        <TabsList className="grid w-full grid-cols-3">
+          <TabsTrigger value="search">
+            <Search className="mr-1.5 h-3.5 w-3.5" /> Search
+          </TabsTrigger>
+          <TabsTrigger value="installed">
+            <Captions className="mr-1.5 h-3.5 w-3.5" /> Installed
+            {installed.length > 0 ? (
+              <span className="ml-1 text-[10px] text-muted-foreground">
+                ({installed.length})
+              </span>
+            ) : null}
+          </TabsTrigger>
+          <TabsTrigger value="upload">
+            <Upload className="mr-1.5 h-3.5 w-3.5" /> Upload
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="search" className="mt-4">
+          <SearchTab
+            itemId={itemId}
+            imdbId={imdbId}
+            tmdbId={tmdbId}
+            query={media.Name || ""}
+            year={media.ProductionYear?.toString()}
+            fileFps={fileFps}
+            onInstalled={refreshInstalled}
+          />
+        </TabsContent>
+
+        <TabsContent value="installed" className="mt-4">
+          <InstalledTab
+            itemId={itemId}
+            installed={installed}
+            loading={loadingInstalled}
+            onChanged={refreshInstalled}
+          />
+        </TabsContent>
+
+        <TabsContent value="upload" className="mt-4">
+          <UploadTab itemId={itemId} onUploaded={refreshInstalled} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function SearchTab({
+  itemId,
+  imdbId,
+  tmdbId,
+  query,
+  year,
+  fileFps,
+  onInstalled,
+}: {
+  itemId: string;
+  imdbId?: string;
+  tmdbId?: string;
+  query: string;
+  year?: string;
+  fileFps: number | null;
+  onInstalled: () => void;
+}) {
+  const [languages, setLanguages] = useState("en");
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [installingId, setInstallingId] = useState<number | null>(null);
+  const hasSearched = useRef(false);
+
+  const runSearch = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (imdbId) params.set("imdbId", imdbId);
+      if (tmdbId) params.set("tmdbId", tmdbId);
+      // Only fall back to a free-text query if we have no precise id.
+      if (!imdbId && !tmdbId && query) params.set("query", query);
+      if (year) params.set("year", year);
+      if (languages.trim()) params.set("languages", languages.trim());
+
+      const res = await fetch(`/api/subtitles/search?${params.toString()}`);
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data?.message || "Search failed");
+      }
+      setResults(data.results || []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Search failed");
+      setResults([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [imdbId, tmdbId, query, year, languages]);
+
+  // Auto-run once when the tab first mounts.
+  useEffect(() => {
+    if (!hasSearched.current) {
+      hasSearched.current = true;
+      runSearch();
+    }
+  }, [runSearch]);
+
+  const install = async (result: SearchResult) => {
+    if (!result.fileId) {
+      toast.error("This result has no downloadable file");
+      return;
+    }
+    setInstallingId(result.fileId);
+    const toastId = toast.loading("Downloading subtitle…");
+    try {
+      const dlRes = await fetch("/api/subtitles/download", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ fileId: result.fileId }),
+      });
+      const dl = await dlRes.json();
+      if (!dlRes.ok) throw new Error(dl?.message || "Download failed");
+
+      const upload = await uploadSubtitleToJellyfin(itemId, {
+        language: result.language || "und",
+        format: dl.format,
+        contentBase64: dl.contentBase64,
+        isHearingImpaired: result.hearingImpaired,
+      });
+      if (!upload.success) throw new Error(upload.message || "Upload failed");
+
+      const remainingMsg =
+        typeof dl.remaining === "number"
+          ? ` (${dl.remaining} downloads left today)`
+          : "";
+      toast.success(`Subtitle added${remainingMsg}`, { id: toastId });
+      onInstalled();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to add subtitle", {
+        id: toastId,
+      });
+    } finally {
+      setInstallingId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-end gap-2">
+        <div className="flex-1 space-y-1.5">
+          <Label htmlFor="sub-langs" className="text-xs">
+            Languages (comma separated ISO codes)
+          </Label>
+          <Input
+            id="sub-langs"
+            value={languages}
+            onChange={(e) => setLanguages(e.target.value)}
+            placeholder="en,es,pt-br"
+            className="h-9 bg-background/50"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") runSearch();
+            }}
+          />
+        </div>
+        <Button size="sm" className="h-9 gap-1.5" onClick={runSearch} disabled={loading}>
+          {loading ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Search className="h-4 w-4" />
+          )}
+          Search
+        </Button>
+      </div>
+
+      {!imdbId && !tmdbId ? (
+        <p className="flex items-center gap-1.5 text-[11px] text-amber-500">
+          <AlertTriangle className="h-3.5 w-3.5" />
+          No IMDb/TMDB id on this item — searching by title, results may be less
+          precise.
+        </p>
+      ) : null}
+
+      {error ? (
+        <div className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-xs text-destructive">
+          {error}
+        </div>
+      ) : null}
+
+      <ScrollArea className="h-[min(45vh,360px)] rounded-md border border-border/40">
+        {loading ? (
+          <div className="flex h-[min(45vh,360px)] items-center justify-center text-muted-foreground">
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Searching…
+          </div>
+        ) : results.length === 0 ? (
+          <div className="flex h-[min(45vh,360px)] items-center justify-center text-sm text-muted-foreground">
+            No subtitles found.
+          </div>
+        ) : (
+          <div className="divide-y divide-border/40">
+            {results.map((r, i) => {
+              const fpsMatch =
+                r.fps && fileFps
+                  ? Math.abs(r.fps - fileFps) < 0.05
+                  : false;
+              return (
+                <div
+                  key={`${r.fileId}-${i}`}
+                  className="flex items-start gap-3 p-3"
+                >
+                  <Flag language={r.language} size={18} className="mt-0.5" />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium" title={r.release || r.fileName}>
+                      {r.release || r.fileName}
+                    </p>
+                    <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[10px]">
+                      <Badge variant="outline" className="uppercase">
+                        {r.language || "??"}
+                      </Badge>
+                      {r.fps ? (
+                        <Badge
+                          variant={fpsMatch ? "default" : "secondary"}
+                          className={fpsMatch ? "bg-green-600 hover:bg-green-600" : ""}
+                        >
+                          {r.fps.toFixed(3)} fps{fpsMatch ? " ✓" : ""}
+                        </Badge>
+                      ) : null}
+                      <Badge variant="secondary">
+                        <Download className="mr-1 h-3 w-3" />
+                        {r.downloadCount.toLocaleString()}
+                      </Badge>
+                      {r.fromTrusted ? (
+                        <Badge variant="secondary" className="text-green-500">
+                          trusted
+                        </Badge>
+                      ) : null}
+                      {r.hd ? <Badge variant="secondary">HD</Badge> : null}
+                      {r.hearingImpaired ? (
+                        <Badge variant="secondary">HI</Badge>
+                      ) : null}
+                      {r.aiTranslated || r.machineTranslated ? (
+                        <Badge variant="secondary" className="text-amber-500">
+                          auto-translated
+                        </Badge>
+                      ) : null}
+                    </div>
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-8 shrink-0 gap-1.5"
+                    disabled={installingId !== null || !r.fileId}
+                    onClick={() => install(r)}
+                  >
+                    {installingId === r.fileId ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <Download className="h-3.5 w-3.5" />
+                    )}
+                    Add
+                  </Button>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </ScrollArea>
+    </div>
+  );
+}
+
+function InstalledTab({
+  itemId,
+  installed,
+  loading,
+  onChanged,
+}: {
+  itemId: string;
+  installed: InstalledSubtitle[];
+  loading: boolean;
+  onChanged: () => void;
+}) {
+  const [deletingIndex, setDeletingIndex] = useState<number | null>(null);
+
+  const remove = async (sub: InstalledSubtitle) => {
+    setDeletingIndex(sub.index);
+    const toastId = toast.loading("Removing subtitle…");
+    try {
+      const res = await deleteJellyfinSubtitle(itemId, sub.index);
+      if (!res.success) throw new Error(res.message || "Delete failed");
+      toast.success("Subtitle removed", { id: toastId });
+      onChanged();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to remove", {
+        id: toastId,
+      });
+    } finally {
+      setDeletingIndex(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex h-[min(45vh,360px)] items-center justify-center text-muted-foreground">
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Loading…
+      </div>
+    );
+  }
+
+  if (installed.length === 0) {
+    return (
+      <div className="flex h-[min(45vh,360px)] items-center justify-center text-sm text-muted-foreground">
+        No subtitles installed yet.
+      </div>
+    );
+  }
+
+  return (
+    <ScrollArea className="h-[min(45vh,360px)] rounded-md border border-border/40">
+      <div className="divide-y divide-border/40">
+        {installed.map((sub) => (
+          <div key={sub.index} className="flex items-center gap-3 p-3">
+            <Flag language={sub.language} size={18} />
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-medium">{sub.displayTitle}</p>
+              <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[10px]">
+                <Badge variant="outline">
+                  {sub.isExternal ? "external" : "embedded"}
+                </Badge>
+                {sub.codec ? (
+                  <Badge variant="secondary" className="uppercase">
+                    {sub.codec}
+                  </Badge>
+                ) : null}
+                {sub.isDefault ? <Badge variant="secondary">default</Badge> : null}
+                {sub.isForced ? <Badge variant="secondary">forced</Badge> : null}
+                {sub.isHearingImpaired ? (
+                  <Badge variant="secondary">HI</Badge>
+                ) : null}
+              </div>
+            </div>
+            {sub.isExternal ? (
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-8 shrink-0 text-destructive hover:text-destructive"
+                disabled={deletingIndex !== null}
+                onClick={() => remove(sub)}
+              >
+                {deletingIndex === sub.index ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Trash2 className="h-3.5 w-3.5" />
+                )}
+              </Button>
+            ) : (
+              <span className="shrink-0 text-[10px] text-muted-foreground">
+                in container
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+    </ScrollArea>
+  );
+}
+
+function UploadTab({
+  itemId,
+  onUploaded,
+}: {
+  itemId: string;
+  onUploaded: () => void;
+}) {
+  const [language, setLanguage] = useState("en");
+  const [forced, setForced] = useState(false);
+  const [file, setFile] = useState<File | null>(null);
+  const [dragging, setDragging] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const ACCEPTED = [".srt", ".ass", ".ssa", ".vtt", ".sub", ".smi"];
+
+  const pick = (f: File | null) => {
+    if (!f) return;
+    const ext = "." + (f.name.split(".").pop()?.toLowerCase() || "");
+    if (!ACCEPTED.includes(ext)) {
+      toast.error(`Unsupported file type. Use ${ACCEPTED.join(", ")}`);
+      return;
+    }
+    setFile(f);
+  };
+
+  const submit = async () => {
+    if (!file) return;
+    setUploading(true);
+    const toastId = toast.loading("Uploading subtitle…");
+    try {
+      const buf = await file.arrayBuffer();
+      const bytes = new Uint8Array(buf);
+      let binary = "";
+      for (let i = 0; i < bytes.length; i++) {
+        binary += String.fromCharCode(bytes[i]);
+      }
+      const base64 = btoa(binary);
+      const format = file.name.split(".").pop()?.toLowerCase() || "srt";
+
+      const res = await uploadSubtitleToJellyfin(itemId, {
+        language: language.trim() || "und",
+        format,
+        contentBase64: base64,
+        isForced: forced,
+      });
+      if (!res.success) throw new Error(res.message || "Upload failed");
+      toast.success("Subtitle uploaded", { id: toastId });
+      setFile(null);
+      onUploaded();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Upload failed", {
+        id: toastId,
+      });
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={() => inputRef.current?.click()}
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDragging(true);
+        }}
+        onDragLeave={() => setDragging(false)}
+        onDrop={(e) => {
+          e.preventDefault();
+          setDragging(false);
+          pick(e.dataTransfer.files?.[0] ?? null);
+        }}
+        className={`flex h-36 cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed transition ${
+          dragging
+            ? "border-primary bg-primary/10"
+            : "border-border/60 bg-background/40 hover:border-primary/60"
+        }`}
+      >
+        {file ? (
+          <div className="flex items-center gap-2 text-sm text-foreground">
+            <CheckCircle2 className="h-5 w-5 text-green-500" />
+            {file.name}
+          </div>
+        ) : (
+          <>
+            <Upload className="mb-2 h-6 w-6 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">
+              Drag &amp; drop a subtitle file, or click to browse
+            </p>
+            <p className="mt-1 text-[10px] text-muted-foreground">
+              {ACCEPTED.join("  ")}
+            </p>
+          </>
+        )}
+        <input
+          ref={inputRef}
+          type="file"
+          accept={ACCEPTED.join(",")}
+          className="hidden"
+          onChange={(e) => pick(e.target.files?.[0] ?? null)}
+        />
+      </div>
+
+      <div className="flex flex-wrap items-end gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="upload-lang" className="text-xs">
+            Language (ISO code)
+          </Label>
+          <Input
+            id="upload-lang"
+            value={language}
+            onChange={(e) => setLanguage(e.target.value)}
+            placeholder="en"
+            className="h-9 w-28 bg-background/50"
+          />
+        </div>
+        <label className="flex cursor-pointer items-center gap-2 pb-2 text-xs text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={forced}
+            onChange={(e) => setForced(e.target.checked)}
+            className="h-3.5 w-3.5"
+          />
+          Forced
+        </label>
+        <Button
+          size="sm"
+          className="ml-auto h-9 gap-1.5"
+          disabled={!file || uploading}
+          onClick={submit}
+        >
+          {uploading ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Upload className="h-4 w-4" />
+          )}
+          Upload
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/opensubtitles.ts
+++ b/src/lib/opensubtitles.ts
@@ -1,0 +1,313 @@
+import type { OpenSubtitlesConfig } from "@/src/actions/store/server-actions";
+
+// Thin server-side client for the OpenSubtitles.com REST API.
+// Docs: https://opensubtitles.stoplight.io/docs/opensubtitles-api
+//
+// All credentials stay on the server: this module is only ever imported by the
+// /api/subtitles/* route handlers, which read them from the httpOnly
+// `opensubtitles-config` cookie and pass them in here.
+
+const DEFAULT_BASE_URL = "https://api.opensubtitles.com/api/v1";
+// OpenSubtitles requires a descriptive, app-specific User-Agent.
+const USER_AGENT = "Aperture Subtitle Finder v1.0";
+
+interface CachedLogin {
+  token: string;
+  baseUrl: string;
+  expiresAt: number;
+}
+
+// Module-level cache. Aperture runs as a long-lived `bun run start` server, so
+// this persists across requests and avoids re-logging-in (which counts against
+// the account) on every search/download. Keyed by apiKey+username.
+const loginCache = new Map<string, CachedLogin>();
+// Login tokens are valid ~24h; refresh a little early to be safe.
+const TOKEN_TTL_MS = 23 * 60 * 60 * 1000;
+
+function loginKey(config: OpenSubtitlesConfig): string {
+  return `${config.apiKey}::${config.username}`;
+}
+
+function baseHeaders(apiKey: string): Record<string, string> {
+  return {
+    "Api-Key": apiKey,
+    "User-Agent": USER_AGENT,
+    "Content-Type": "application/json",
+    Accept: "application/json",
+  };
+}
+
+export class OpenSubtitlesError extends Error {
+  status: number;
+  constructor(message: string, status = 500) {
+    super(message);
+    this.status = status;
+    this.name = "OpenSubtitlesError";
+  }
+}
+
+async function login(config: OpenSubtitlesConfig): Promise<CachedLogin> {
+  const cached = loginCache.get(loginKey(config));
+  if (cached && cached.expiresAt > nowMs()) {
+    return cached;
+  }
+
+  const res = await fetch(`${DEFAULT_BASE_URL}/login`, {
+    method: "POST",
+    headers: baseHeaders(config.apiKey),
+    body: JSON.stringify({
+      username: config.username,
+      password: config.password,
+    }),
+  });
+
+  if (!res.ok) {
+    const detail = await safeError(res);
+    throw new OpenSubtitlesError(
+      `OpenSubtitles login failed: ${detail}`,
+      res.status === 401 ? 401 : 502,
+    );
+  }
+
+  const data = (await res.json()) as {
+    token?: string;
+    base_url?: string;
+  };
+
+  if (!data.token) {
+    throw new OpenSubtitlesError("OpenSubtitles login returned no token", 502);
+  }
+
+  // The API may hand back a dedicated base_url (e.g. a VIP subdomain) that
+  // should be used for subsequent authenticated calls like /download.
+  const baseUrl = data.base_url
+    ? `https://${data.base_url.replace(/^https?:\/\//, "").replace(/\/+$/, "")}/api/v1`
+    : DEFAULT_BASE_URL;
+
+  const entry: CachedLogin = {
+    token: data.token,
+    baseUrl,
+    expiresAt: nowMs() + TOKEN_TTL_MS,
+  };
+  loginCache.set(loginKey(config), entry);
+  return entry;
+}
+
+export interface SubtitleSearchParams {
+  imdbId?: string;
+  tmdbId?: string;
+  query?: string;
+  languages?: string; // comma separated, lower-case ISO 639
+  year?: string;
+  seasonNumber?: string;
+  episodeNumber?: string;
+}
+
+export interface SubtitleResult {
+  fileId: number | null;
+  fileName: string;
+  language: string;
+  release: string;
+  fps: number | null;
+  downloadCount: number;
+  ratings: number;
+  fromTrusted: boolean;
+  hearingImpaired: boolean;
+  hd: boolean;
+  aiTranslated: boolean;
+  machineTranslated: boolean;
+  uploadDate: string | null;
+}
+
+export async function searchSubtitles(
+  config: OpenSubtitlesConfig,
+  params: SubtitleSearchParams,
+): Promise<SubtitleResult[]> {
+  const search = new URLSearchParams();
+  if (params.imdbId) search.set("imdb_id", stripImdb(params.imdbId));
+  if (params.tmdbId) search.set("tmdb_id", params.tmdbId);
+  if (params.query) search.set("query", params.query);
+  if (params.languages) search.set("languages", params.languages.toLowerCase());
+  if (params.year) search.set("year", params.year);
+  if (params.seasonNumber) search.set("season_number", params.seasonNumber);
+  if (params.episodeNumber) search.set("episode_number", params.episodeNumber);
+  // Most-downloaded first tends to surface the well-synced releases.
+  search.set("order_by", "download_count");
+
+  // Search works unauthenticated, but sending the token (when we have one
+  // cached) is harmless and keeps behaviour consistent.
+  const headers = baseHeaders(config.apiKey);
+  const cached = loginCache.get(loginKey(config));
+  if (cached && cached.expiresAt > nowMs()) {
+    headers["Authorization"] = `Bearer ${cached.token}`;
+  }
+
+  const res = await fetch(`${DEFAULT_BASE_URL}/subtitles?${search.toString()}`, {
+    method: "GET",
+    headers,
+  });
+
+  if (!res.ok) {
+    const detail = await safeError(res);
+    throw new OpenSubtitlesError(
+      `OpenSubtitles search failed: ${detail}`,
+      res.status === 401 ? 401 : 502,
+    );
+  }
+
+  const json = (await res.json()) as { data?: any[] };
+  const items = Array.isArray(json.data) ? json.data : [];
+
+  return items.map((item): SubtitleResult => {
+    const attr = item?.attributes ?? {};
+    const file = Array.isArray(attr.files) ? attr.files[0] : undefined;
+    return {
+      fileId: typeof file?.file_id === "number" ? file.file_id : null,
+      fileName: file?.file_name || attr.release || "subtitle",
+      language: attr.language || "",
+      release: attr.release || "",
+      fps: typeof attr.fps === "number" && attr.fps > 0 ? attr.fps : null,
+      downloadCount:
+        typeof attr.download_count === "number" ? attr.download_count : 0,
+      ratings: typeof attr.ratings === "number" ? attr.ratings : 0,
+      fromTrusted: !!attr.from_trusted,
+      hearingImpaired: !!attr.hearing_impaired,
+      hd: !!attr.hd,
+      aiTranslated: !!attr.ai_translated,
+      machineTranslated: !!attr.machine_translated,
+      uploadDate: attr.upload_date || null,
+    };
+  });
+}
+
+export interface DownloadedSubtitle {
+  // Base64-encoded subtitle file content, ready for Jellyfin's upload endpoint.
+  contentBase64: string;
+  fileName: string;
+  format: string; // e.g. "srt", "ass"
+  remaining: number | null; // remaining daily download quota
+}
+
+export async function downloadSubtitle(
+  config: OpenSubtitlesConfig,
+  fileId: number,
+): Promise<DownloadedSubtitle> {
+  // Download requires authentication and consumes daily quota.
+  const session = await login(config);
+
+  const res = await fetch(`${session.baseUrl}/download`, {
+    method: "POST",
+    headers: {
+      ...baseHeaders(config.apiKey),
+      Authorization: `Bearer ${session.token}`,
+    },
+    body: JSON.stringify({ file_id: fileId }),
+  });
+
+  if (!res.ok) {
+    const detail = await safeError(res);
+    throw new OpenSubtitlesError(
+      `OpenSubtitles download request failed: ${detail}`,
+      res.status === 401 ? 401 : 502,
+    );
+  }
+
+  const data = (await res.json()) as {
+    link?: string;
+    file_name?: string;
+    remaining?: number;
+  };
+
+  if (!data.link) {
+    throw new OpenSubtitlesError(
+      "OpenSubtitles did not return a download link (daily quota may be exhausted)",
+      429,
+    );
+  }
+
+  // The link is a temporary, pre-signed URL to the actual subtitle file.
+  const fileRes = await fetch(data.link);
+  if (!fileRes.ok) {
+    throw new OpenSubtitlesError(
+      `Failed to fetch subtitle file: ${fileRes.status}`,
+      502,
+    );
+  }
+
+  const buffer = Buffer.from(await fileRes.arrayBuffer());
+  const fileName = data.file_name || "subtitle.srt";
+
+  return {
+    contentBase64: buffer.toString("base64"),
+    fileName,
+    format: formatFromName(fileName),
+    remaining: typeof data.remaining === "number" ? data.remaining : null,
+  };
+}
+
+export interface QuotaInfo {
+  allowed: number | null;
+  remaining: number | null;
+  resetTime: string | null;
+  level: string | null;
+}
+
+// Validates credentials by logging in, then reads the account's quota.
+export async function testConnection(
+  config: OpenSubtitlesConfig,
+): Promise<QuotaInfo> {
+  // Force a fresh login so a saved-but-now-invalid key is actually re-checked.
+  loginCache.delete(loginKey(config));
+  const session = await login(config);
+
+  const res = await fetch(`${session.baseUrl}/infos/user`, {
+    method: "GET",
+    headers: {
+      ...baseHeaders(config.apiKey),
+      Authorization: `Bearer ${session.token}`,
+    },
+  });
+
+  if (!res.ok) {
+    // Login already succeeded, so credentials are valid even if this lookup
+    // fails for some reason; report unknown quota rather than erroring.
+    return { allowed: null, remaining: null, resetTime: null, level: null };
+  }
+
+  const json = (await res.json()) as { data?: any };
+  const d = json.data ?? {};
+  return {
+    allowed: typeof d.allowed_downloads === "number" ? d.allowed_downloads : null,
+    remaining:
+      typeof d.remaining_downloads === "number" ? d.remaining_downloads : null,
+    resetTime: d.reset_time || null,
+    level: d.level || null,
+  };
+}
+
+// --- helpers ---
+
+function nowMs(): number {
+  // Date.now() is fine in app code (the restriction is only on workflow scripts).
+  return Date.now();
+}
+
+function stripImdb(id: string): string {
+  // OpenSubtitles expects a numeric IMDb id; Jellyfin stores it as "tt0133093".
+  return id.replace(/^tt/i, "").replace(/^0+/, "");
+}
+
+function formatFromName(fileName: string): string {
+  const ext = fileName.split(".").pop()?.toLowerCase() || "";
+  const known = ["srt", "ass", "ssa", "vtt", "sub", "smi"];
+  return known.includes(ext) ? ext : "srt";
+}
+
+async function safeError(res: Response): Promise<string> {
+  try {
+    const json = await res.json();
+    return json?.message || json?.error || `HTTP ${res.status}`;
+  } catch {
+    return `HTTP ${res.status}`;
+  }
+}


### PR DESCRIPTION
## Summary

Adds an [OpenSubtitles.com](https://www.opensubtitles.com) integration so users can search, download, and manage subtitles for their media directly from Aperture.

## What's included

- **Settings section** to configure OpenSubtitles credentials (API key, username, password, preferred languages). Credentials are stored in an **httpOnly** cookie and only ever read server-side — never exposed to client JavaScript.
- **Server-side OpenSubtitles REST client** (`src/lib/opensubtitles.ts`) — a thin wrapper over the OpenSubtitles v1 API with login-token caching so we don't re-authenticate on every request (login attempts count against the account).
- **Route handlers** under `/api/subtitles/{search,download,test}`.
- **Subtitle manager dialog** on media items: search by provider id, download a subtitle and upload it to Jellyfin, and remove already-installed subtitles.
- `fetchMediaDetails` now requests `ProviderIds` so external ids (IMDb/TMDb) are available for accurate subtitle matching.

## Notes

- No new env vars required; configuration lives entirely in the new settings section.
- All third-party credentials are kept server-side via an httpOnly cookie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)