### PR TITLE
feat: Implement remember-me session management

### DIFF
--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "@/src/hooks/useAuth";
 import { PlaybackProvider } from "@/src/playback/context/PlaybackProvider";
 import { SeerrProvider } from "@/src/contexts/seerr-context";
 import { AuthErrorHandler } from "@/src/components/auth-error-handler";
+import { refreshAuthCookieTTL } from "@/src/actions/store/server-actions";
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 
@@ -22,6 +23,12 @@ export default function MainLayout({
       router.push("/login");
     }
   }, [isLoading, isAuthenticated, router]);
+
+  useEffect(() => {
+    if (!isLoading && isAuthenticated) {
+      refreshAuthCookieTTL().catch(() => {});
+    }
+  }, [isLoading, isAuthenticated]);
 
   return (
     <JotaiProvider>

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -25,9 +25,16 @@ export default function MainLayout({
   }, [isLoading, isAuthenticated, router]);
 
   useEffect(() => {
-    if (!isLoading && isAuthenticated) {
-      refreshAuthCookieTTL().catch(() => {});
-    }
+    if (isLoading || !isAuthenticated) return;
+
+    // Call once immediately, then every hour to slide the idle-expiry window
+    refreshAuthCookieTTL().catch(() => {});
+
+    const interval = setInterval(
+      () => refreshAuthCookieTTL().catch(() => {}),
+      60 * 60 * 1000, // 1 hour
+    );
+    return () => clearInterval(interval);
   }, [isLoading, isAuthenticated]);
 
   return (

--- a/app/api/seerr/[...slug]/route.ts
+++ b/app/api/seerr/[...slug]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { SeerrMediaItem, SeerrRequestItem } from "@/src/types/seerr-types";
+import { SeerrMediaItem } from "@/src/types/seerr-types";
 
 // Shared map to track pending logins per user/server
 // Note: In serverless environments, this map might be reset frequently.
@@ -160,7 +160,7 @@ async function hydrateSeerrItems(
       const detailResponse = await seerrFetch<any>(req, detailEndpoint);
 
       if (detailResponse.success && detailResponse.data) {
-        let merged = { ...item, ...detailResponse.data };
+        const merged = { ...item, ...detailResponse.data };
         merged.tmdbId = tmdbId;
         return merged as SeerrMediaItem;
       }

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -155,6 +155,9 @@ export async function authenticateUser(
         { persistent: rememberMe },
       );
 
+      // Keep the server URL cookie lifetime aligned with the session choice.
+      await StoreServerURL.set(serverUrl, { persistent: rememberMe });
+
       return true;
     } else {
       console.error("Authentication response missing AccessToken");
@@ -224,6 +227,9 @@ export async function authenticateUser(
             },
             { persistent: rememberMe },
           );
+
+          // Keep the server URL cookie lifetime aligned with the session choice.
+          await StoreServerURL.set(serverUrl, { persistent: rememberMe });
 
           return true;
         }
@@ -441,6 +447,9 @@ export async function authenticateWithQuickConnect(
         { persistent: rememberMe },
       );
 
+      // Keep the server URL cookie lifetime aligned with the session choice.
+      await StoreServerURL.set(serverUrl, { persistent: rememberMe });
+
       return true;
     }
 
@@ -451,14 +460,29 @@ export async function authenticateWithQuickConnect(
   }
 }
 
-export function logout(navigate: (redirectPath: string) => void) {
-  Promise.all([
+export async function logout(
+  navigate: (redirectPath: string) => void,
+): Promise<void> {
+  // Non-blocking server-side token revocation to keep jellyfin sessions clean.
+  try {
+    const authData = await StoreAuthData.get();
+    if (authData?.serverUrl && (authData.user as any)?.AccessToken) {
+      await fetch(`${authData.serverUrl}/Sessions/Logout`, {
+        method: "POST",
+        headers: {
+          Authorization: `MediaBrowser Token="${(authData.user as any).AccessToken}"`,
+        },
+      });
+    }
+  } catch {}
+
+  await Promise.all([
     StoreAuthData.remove(),
     StoreServerURL.remove(),
     StoreSeerrData.remove(),
-  ]).then(() => {
-    navigate("/login");
-  });
+  ]);
+
+  navigate("/login");
 }
 
 export async function getUser(): Promise<JellyfinUserWithToken | null> {

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -476,11 +476,7 @@ export async function logout(
     }
   } catch {}
 
-  await Promise.all([
-    StoreAuthData.remove(),
-    StoreServerURL.remove(),
-    StoreSeerrData.remove(),
-  ]);
+  await Promise.all([StoreAuthData.remove(), StoreSeerrData.remove()]);
 
   navigate("/login");
 }

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -111,6 +111,7 @@ export async function checkServerHealth(
 export async function authenticateUser(
   username: string,
   password: string,
+  rememberMe: boolean = false,
 ): Promise<boolean> {
   const serverUrl = await getServerUrl();
   if (!serverUrl) {
@@ -145,11 +146,14 @@ export async function authenticateUser(
     if (result.AccessToken) {
       const userWithToken = { ...result.User, AccessToken: result.AccessToken };
 
-      await StoreAuthData.set({
-        serverUrl,
-        user: userWithToken,
-        timestamp: Date.now(), // track token age
-      });
+      await StoreAuthData.set(
+        {
+          serverUrl,
+          user: userWithToken,
+          timestamp: Date.now(), // track token age
+        },
+        { persistent: rememberMe },
+      );
 
       return true;
     } else {
@@ -212,11 +216,14 @@ export async function authenticateUser(
             AccessToken: result.AccessToken,
           };
 
-          await StoreAuthData.set({
-            serverUrl,
-            user: userWithToken,
-            timestamp: Date.now(), // track token age
-          });
+          await StoreAuthData.set(
+            {
+              serverUrl,
+              user: userWithToken,
+              timestamp: Date.now(), // track token age
+            },
+            { persistent: rememberMe },
+          );
 
           return true;
         }
@@ -392,6 +399,7 @@ export async function getQuickConnectStatus(
 
 export async function authenticateWithQuickConnect(
   secret: string,
+  rememberMe: boolean = false,
 ): Promise<boolean> {
   const serverUrl = await getServerUrl();
   if (!serverUrl || !secret) return false;
@@ -424,11 +432,14 @@ export async function authenticateWithQuickConnect(
         AccessToken: result.AccessToken,
       };
 
-      await StoreAuthData.set({
-        serverUrl,
-        user: userWithToken,
-        timestamp: Date.now(),
-      });
+      await StoreAuthData.set(
+        {
+          serverUrl,
+          user: userWithToken,
+          timestamp: Date.now(),
+        },
+        { persistent: rememberMe },
+      );
 
       return true;
     }

--- a/src/actions/media.ts
+++ b/src/actions/media.ts
@@ -15,7 +15,6 @@ import { getTvShowsApi } from "@jellyfin/sdk/lib/utils/api/tv-shows-api";
 import { createJellyfinInstance } from "../lib/utils";
 import { JellyfinUserWithToken } from "../types/jellyfin";
 import { StoreAuthData } from "./store/store-auth-data";
-import { StoreServerURL } from "./store/store-server-url";
 import { LibraryOptions } from "@jellyfin/sdk/lib/generated-client/models";
 
 // Type aliases for easier use

--- a/src/actions/store/server-actions.ts
+++ b/src/actions/store/server-actions.ts
@@ -85,7 +85,11 @@ export async function setServerUrl(
 export async function getServerUrl(): Promise<string | null> {
   const cookieStore = await cookies();
   const val = cookieStore.get(SERVER_URL_KEY);
-  return val ? val.value : null;
+  if (val?.value) {
+    return val.value;
+  }
+  const envDefault = process.env.DEFAULT_SERVER_URL?.trim();
+  return envDefault || null;
 }
 
 export async function removeServerUrl() {
@@ -148,11 +152,10 @@ export async function getAuthData(): Promise<AuthData | null> {
 
   try {
     const parsed = JSON.parse(val.value) as AuthData;
-    // Non-remembered sessions carry an idle-expiry. If the expiry has passed, clean up
-    // both the auth cookie and the server URL
+    // Non-remembered sessions carry an idle-expiry. If the expiry has passed,
+    // clear only auth so server URL preference can still be reused.
     if (parsed.expiresAt && Date.now() > parsed.expiresAt) {
       cookieStore.delete(AUTH_DATA_KEY);
-      cookieStore.delete(SERVER_URL_KEY);
       return null;
     }
     return parsed;

--- a/src/actions/store/server-actions.ts
+++ b/src/actions/store/server-actions.ts
@@ -14,6 +14,9 @@ export interface AuthData {
   serverUrl: string;
   user: AuthenticationResult & { AccessToken: string };
   timestamp: number;
+  // Present only for non-remembered sessions. Absolute idle-expiry so the
+  // session ends even if the browser restores its session cookie.
+  expiresAt?: number;
 }
 
 export type SeerrAuthType = "api-key" | "jellyfin-user" | "local-user";
@@ -27,7 +30,14 @@ export type SeerrAuthData =
       password: string;
     };
 
-const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365; // 1 year — auth tokens live until revoked
+// Login preferences contain no secrets. Keep them much longer so prefill data survives auth-cookie expiry.
+const LOGIN_PREFS_MAX_AGE_SECONDS = 60 * 60 * 24 * 365 * 10; // 10 years
+
+// Idle window for non-remembered ("Keep me signed in" unchecked) sessions.
+// Even if the browser restores a session cookie (e.g. Chrome "Continue where
+// you left off"), the session is treated as expired after this much inactivity.
+const SESSION_MAX_IDLE_SECONDS = 60 * 60 * 8; // 8 hours
 
 function getPersistentCookieOptions() {
   return {
@@ -36,6 +46,16 @@ function getPersistentCookieOptions() {
     secure: process.env.NODE_ENV === "production",
     path: "/",
     maxAge: COOKIE_MAX_AGE_SECONDS,
+  };
+}
+
+function getLoginPrefsCookieOptions() {
+  return {
+    httpOnly: true,
+    sameSite: "lax" as const,
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: LOGIN_PREFS_MAX_AGE_SECONDS,
   };
 }
 
@@ -51,8 +71,15 @@ function getSessionCookieOptions() {
 // --- StoreServerURL actions ---
 const SERVER_URL_KEY = "jellyfin-server-url";
 
-export async function setServerUrl(value: string) {
-  (await cookies()).set(SERVER_URL_KEY, value, getPersistentCookieOptions());
+export async function setServerUrl(
+  value: string,
+  options?: { persistent?: boolean },
+) {
+  const cookieOptions =
+    options?.persistent === false
+      ? getSessionCookieOptions()
+      : getPersistentCookieOptions();
+  (await cookies()).set(SERVER_URL_KEY, value, cookieOptions);
 }
 
 export async function getServerUrl(): Promise<string | null> {
@@ -72,7 +99,7 @@ export async function setLoginPreferences(value: LoginPreferences) {
   (await cookies()).set(
     PREF_KEY,
     JSON.stringify(value),
-    getPersistentCookieOptions(),
+    getLoginPrefsCookieOptions(),
   );
 }
 
@@ -98,11 +125,20 @@ export async function setAuthData(
   value: AuthData,
   options?: { persistent?: boolean },
 ) {
-  const cookieOptions = options?.persistent
+  const persistent = options?.persistent === true;
+  const dataToStore: AuthData = persistent
+    ? { ...value, expiresAt: undefined }
+    : { ...value, expiresAt: Date.now() + SESSION_MAX_IDLE_SECONDS * 1000 };
+
+  const cookieOptions = persistent
     ? getPersistentCookieOptions()
     : getSessionCookieOptions();
 
-  (await cookies()).set(AUTH_DATA_KEY, JSON.stringify(value), cookieOptions);
+  (await cookies()).set(
+    AUTH_DATA_KEY,
+    JSON.stringify(dataToStore),
+    cookieOptions,
+  );
 }
 
 export async function getAuthData(): Promise<AuthData | null> {
@@ -111,8 +147,15 @@ export async function getAuthData(): Promise<AuthData | null> {
   if (!val || !val.value) return null;
 
   try {
-    const parsed = JSON.parse(val.value);
-    return parsed as AuthData;
+    const parsed = JSON.parse(val.value) as AuthData;
+    // Non-remembered sessions carry an idle-expiry. If the expiry has passed, clean up
+    // both the auth cookie and the server URL
+    if (parsed.expiresAt && Date.now() > parsed.expiresAt) {
+      cookieStore.delete(AUTH_DATA_KEY);
+      cookieStore.delete(SERVER_URL_KEY);
+      return null;
+    }
+    return parsed;
   } catch {
     return null;
   }
@@ -120,6 +163,69 @@ export async function getAuthData(): Promise<AuthData | null> {
 
 export async function removeAuthData() {
   (await cookies()).delete(AUTH_DATA_KEY);
+}
+
+// Slide the auth cookie TTL on each authenticated visit so active users never
+// get logged out while the Jellyfin token is still valid.
+// Only applies persistent TTL if the user opted in via "Keep me signed in".
+export async function refreshAuthCookieTTL(): Promise<void> {
+  const cookieStore = await cookies();
+  const val = cookieStore.get(AUTH_DATA_KEY);
+  if (!val?.value) return;
+
+  let parsed: AuthData;
+  try {
+    parsed = JSON.parse(val.value) as AuthData;
+  } catch {
+    return;
+  }
+
+  const prefRaw = cookieStore.get(PREF_KEY);
+  let rememberMe = false;
+  if (prefRaw?.value) {
+    try {
+      const prefs = JSON.parse(prefRaw.value) as LoginPreferences;
+      rememberMe = prefs.rememberMe === true;
+    } catch {}
+  }
+
+  if (rememberMe) {
+    // Stay signed in: drop any idle-expiry and slide the long TTL forward on
+    // auth, server URL, and login preferences
+    const persistentData = { ...parsed };
+    delete persistentData.expiresAt;
+    cookieStore.set(
+      AUTH_DATA_KEY,
+      JSON.stringify(persistentData),
+      getPersistentCookieOptions(),
+    );
+    const serverUrl = cookieStore.get(SERVER_URL_KEY);
+    if (serverUrl?.value) {
+      cookieStore.set(
+        SERVER_URL_KEY,
+        serverUrl.value,
+        getPersistentCookieOptions(),
+      );
+    }
+    if (prefRaw?.value) {
+      cookieStore.set(PREF_KEY, prefRaw.value, getLoginPrefsCookieOptions());
+    }
+    return;
+  }
+
+  // Non-remembered: if the idle window already passed, leave it to expire.
+  if (parsed.expiresAt && Date.now() > parsed.expiresAt) return;
+
+  // Otherwise slide the idle-expiry forward while keeping session-scoped cookies.
+  const refreshed: AuthData = {
+    ...parsed,
+    expiresAt: Date.now() + SESSION_MAX_IDLE_SECONDS * 1000,
+  };
+  cookieStore.set(
+    AUTH_DATA_KEY,
+    JSON.stringify(refreshed),
+    getSessionCookieOptions(),
+  );
 }
 
 export async function executeClearAuthDataAction(
@@ -150,7 +256,7 @@ export async function executeClearAuthDataAction(
           cookieStore.set(
             PREF_KEY,
             JSON.stringify({ ...existingPrefs, username: userName }),
-            getPersistentCookieOptions(),
+            getLoginPrefsCookieOptions(),
           );
         }
       }

--- a/src/actions/store/server-actions.ts
+++ b/src/actions/store/server-actions.ts
@@ -7,6 +7,7 @@ import { AuthenticationResult } from "@jellyfin/sdk/lib/generated-client/models"
 export interface LoginPreferences {
   username?: string;
   serverUrl?: string;
+  rememberMe?: boolean;
 }
 
 export interface AuthData {
@@ -26,11 +27,32 @@ export type SeerrAuthData =
       password: string;
     };
 
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
+
+function getPersistentCookieOptions() {
+  return {
+    httpOnly: true,
+    sameSite: "lax" as const,
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: COOKIE_MAX_AGE_SECONDS,
+  };
+}
+
+function getSessionCookieOptions() {
+  return {
+    httpOnly: true,
+    sameSite: "lax" as const,
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+  };
+}
+
 // --- StoreServerURL actions ---
 const SERVER_URL_KEY = "jellyfin-server-url";
 
 export async function setServerUrl(value: string) {
-  (await cookies()).set(SERVER_URL_KEY, value);
+  (await cookies()).set(SERVER_URL_KEY, value, getPersistentCookieOptions());
 }
 
 export async function getServerUrl(): Promise<string | null> {
@@ -47,7 +69,11 @@ export async function removeServerUrl() {
 const PREF_KEY = "login-preferences";
 
 export async function setLoginPreferences(value: LoginPreferences) {
-  (await cookies()).set(PREF_KEY, JSON.stringify(value));
+  (await cookies()).set(
+    PREF_KEY,
+    JSON.stringify(value),
+    getPersistentCookieOptions(),
+  );
 }
 
 export async function getLoginPreferences(): Promise<LoginPreferences | null> {
@@ -68,8 +94,15 @@ export async function removeLoginPreferences() {
 // --- StoreAuthData actions ---
 const AUTH_DATA_KEY = "jellyfin-auth";
 
-export async function setAuthData(value: AuthData) {
-  (await cookies()).set(AUTH_DATA_KEY, JSON.stringify(value));
+export async function setAuthData(
+  value: AuthData,
+  options?: { persistent?: boolean },
+) {
+  const cookieOptions = options?.persistent
+    ? getPersistentCookieOptions()
+    : getSessionCookieOptions();
+
+  (await cookies()).set(AUTH_DATA_KEY, JSON.stringify(value), cookieOptions);
 }
 
 export async function getAuthData(): Promise<AuthData | null> {
@@ -93,16 +126,32 @@ export async function executeClearAuthDataAction(
   preservePrefs: boolean = true,
 ) {
   const cookieStore = await cookies();
-  
+
   if (preservePrefs) {
     try {
+      let existingPrefs: LoginPreferences = {};
+      const existingPrefsCookie = cookieStore.get(PREF_KEY);
+      if (existingPrefsCookie?.value) {
+        try {
+          existingPrefs = JSON.parse(
+            existingPrefsCookie.value,
+          ) as LoginPreferences;
+        } catch {
+          existingPrefs = {};
+        }
+      }
+
       const val = cookieStore.get(AUTH_DATA_KEY);
       if (val && val.value) {
         const parsed = JSON.parse(val.value) as AuthData;
         const userName =
           (parsed?.user as any)?.Name || parsed?.user?.User?.Name;
         if (userName) {
-          cookieStore.set(PREF_KEY, JSON.stringify({ username: userName }));
+          cookieStore.set(
+            PREF_KEY,
+            JSON.stringify({ ...existingPrefs, username: userName }),
+            getPersistentCookieOptions(),
+          );
         }
       }
     } catch (err) {
@@ -118,8 +167,15 @@ export async function executeClearAuthDataAction(
 // --- StoreSeerrData actions ---
 const SEERR_DATA_KEY = "seerr-config";
 
-export async function setSeerrData(value: SeerrAuthData) {
-  (await cookies()).set(SEERR_DATA_KEY, JSON.stringify(value));
+export async function setSeerrData(
+  value: SeerrAuthData,
+  options?: { persistent?: boolean },
+) {
+  const cookieOptions = options?.persistent
+    ? getPersistentCookieOptions()
+    : getSessionCookieOptions();
+
+  (await cookies()).set(SEERR_DATA_KEY, JSON.stringify(value), cookieOptions);
 }
 
 export async function getSeerrData(): Promise<SeerrAuthData | null> {

--- a/src/actions/store/store-auth-data.ts
+++ b/src/actions/store/store-auth-data.ts
@@ -6,8 +6,8 @@ import {
 } from "./server-actions";
 
 export class StoreAuthData {
-  static async set(value: AuthData) {
-    return setAuthData(value);
+  static async set(value: AuthData, options?: { persistent?: boolean }) {
+    return setAuthData(value, options);
   }
 
   static async get(): Promise<AuthData | null> {

--- a/src/actions/store/store-seerr-data.ts
+++ b/src/actions/store/store-seerr-data.ts
@@ -6,8 +6,8 @@ import {
 } from "./server-actions";
 
 export class StoreSeerrData {
-  static async set(value: SeerrAuthData) {
-    return setSeerrData(value);
+  static async set(value: SeerrAuthData, options?: { persistent?: boolean }) {
+    return setSeerrData(value, options);
   }
 
   static async get(): Promise<SeerrAuthData | null> {

--- a/src/actions/store/store-server-url.ts
+++ b/src/actions/store/store-server-url.ts
@@ -1,8 +1,8 @@
 import { getServerUrl, setServerUrl, removeServerUrl } from "./server-actions";
 
 export class StoreServerURL {
-  static async set(value: string) {
-    return setServerUrl(value);
+  static async set(value: string, options?: { persistent?: boolean }) {
+    return setServerUrl(value, options);
   }
 
   static async get(): Promise<string | null> {

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -7,7 +7,6 @@ import {
   SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,

--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -69,6 +69,7 @@ export function LoginForm({ onSuccess, onBack }: LoginFormProps) {
     null,
   );
   const [quickConnectLoading, setQuickConnectLoading] = useState(false);
+  const [rememberMe, setRememberMe] = useState(true);
 
   const pollTimerRef = useRef<number | null>(null);
   const lastSecretRef = useRef<string | null>(null);
@@ -81,6 +82,19 @@ export function LoginForm({ onSuccess, onBack }: LoginFormProps) {
     }
   }, []);
 
+  const persistLoginPreferences = useCallback(async () => {
+    try {
+      const serverUrl = await getServerUrl();
+      await StoreLoginPreferences.set({
+        username: username.trim() || undefined,
+        serverUrl: serverUrl || undefined,
+        rememberMe,
+      });
+    } catch (error) {
+      console.warn("Failed to persist login preferences:", error);
+    }
+  }, [rememberMe, username]);
+
   useEffect(() => {
     isMountedRef.current = true;
     (async () => {
@@ -88,6 +102,9 @@ export function LoginForm({ onSuccess, onBack }: LoginFormProps) {
       if (!isMountedRef.current) return;
       if (prefs?.username) {
         setUsername(prefs.username);
+      }
+      if (typeof prefs?.rememberMe === "boolean") {
+        setRememberMe(prefs.rememberMe);
       }
     })();
     return () => {
@@ -148,10 +165,11 @@ export function LoginForm({ onSuccess, onBack }: LoginFormProps) {
 
       if (status.Authenticated) {
         stopQuickConnectPolling();
-        const success = await authenticateWithQuickConnect(nextSecret);
+        const success = await authenticateWithQuickConnect(nextSecret, rememberMe);
         if (!isMountedRef.current) return;
 
         if (success) {
+          await persistLoginPreferences();
           onSuccess();
           return;
         }
@@ -170,7 +188,7 @@ export function LoginForm({ onSuccess, onBack }: LoginFormProps) {
           : "We couldn't check the Quick Connect status. Please try again.",
       );
     }
-  }, [onSuccess, stopQuickConnectPolling]);
+  }, [onSuccess, persistLoginPreferences, rememberMe, stopQuickConnectPolling]);
 
   const startQuickConnect = useCallback(async () => {
     if (quickConnectLoading) return;
@@ -255,8 +273,9 @@ export function LoginForm({ onSuccess, onBack }: LoginFormProps) {
     setError("");
 
     try {
-      const success = await authenticateUser(username, password);
+      const success = await authenticateUser(username, password, rememberMe);
       if (success) {
+        await persistLoginPreferences();
         onSuccess();
       } else {
         setError("Invalid username or password. Please try again.");
@@ -370,6 +389,20 @@ export function LoginForm({ onSuccess, onBack }: LoginFormProps) {
                   />
                 </div>
 
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    id="remember-me"
+                    checked={rememberMe}
+                    onCheckedChange={(checked) => setRememberMe(checked === true)}
+                  />
+                  <label
+                    htmlFor="remember-me"
+                    className="text-sm text-muted-foreground"
+                  >
+                    Keep me signed in on this device
+                  </label>
+                </div>
+
                 {error && (
                   <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
                     <AlertCircle className="mt-0.5 h-4 w-4" />
@@ -461,6 +494,20 @@ export function LoginForm({ onSuccess, onBack }: LoginFormProps) {
                   )}
                 </div>
               )}
+
+              <div className="mt-4 flex items-center gap-2">
+                <Checkbox
+                  id="remember-me-quickconnect"
+                  checked={rememberMe}
+                  onCheckedChange={(checked) => setRememberMe(checked === true)}
+                />
+                <label
+                  htmlFor="remember-me-quickconnect"
+                  className="text-sm text-muted-foreground"
+                >
+                  Keep me signed in on this device
+                </label>
+              </div>
             </TabsContent>
           </Tabs>
         </CardContent>

--- a/src/components/onboarding-flow.tsx
+++ b/src/components/onboarding-flow.tsx
@@ -28,8 +28,6 @@ export function OnboardingFlow() {
       if (authenticated && serverUrl) {
         router.push("/");
         return;
-      } else if (serverUrl && !authenticated) {
-        setCurrentStep("login");
       } else {
         setCurrentStep("server");
       }

--- a/src/components/server-setup.tsx
+++ b/src/components/server-setup.tsx
@@ -11,10 +11,9 @@ import {
 import { Input } from "../components/ui/input";
 import { Button } from "../components/ui/button";
 import { VibrantAuroraBackground } from "../components/vibrant-aurora-background";
-import { checkServerHealth, setServerUrl } from "../actions";
+import { checkServerHealth, getServerUrl, setServerUrl } from "../actions";
 import { StoreLoginPreferences } from "../actions/store/store-login-preferences";
 import { Loader2, Server, CheckCircle, Globe, Shield } from "lucide-react";
-import axios from "axios";
 
 interface ServerSetupProps {
   onNext: () => void;
@@ -39,23 +38,18 @@ export function ServerSetup({ onNext }: ServerSetupProps) {
   useEffect(() => {
     async function fetchConfig() {
       try {
-        // 1. Try runtime config (Docker / env-based default)
-        const { data } = await axios("/api/config");
-        if (data.defaultServerUrl) {
-          setUrl(data.defaultServerUrl);
-          return;
+        // Server URL resolution is cookie-first with env-default fallback.
+        const resolvedServerUrl = await getServerUrl();
+        if (resolvedServerUrl) {
+          setUrl(resolvedServerUrl);
+        } else {
+          // Fall back to saved login preferences so returning users see the
+          // server URL they previously connected to.
+          const prefs = await StoreLoginPreferences.get();
+          if (prefs?.serverUrl) setUrl(prefs.serverUrl);
         }
       } catch (err) {
-        console.error("Failed to fetch runtime config", err);
-      }
-
-      try {
-        // 2. Fall back to saved login preferences so returning users see the
-        // server URL they previously connected to.
-        const prefs = await StoreLoginPreferences.get();
-        if (prefs?.serverUrl) setUrl(prefs.serverUrl);
-      } catch (err) {
-        console.error("Failed to read login preferences", err);
+        console.error("Failed to resolve server URL", err);
       } finally {
         setUrlLoading(false);
       }

--- a/src/components/server-setup.tsx
+++ b/src/components/server-setup.tsx
@@ -12,6 +12,7 @@ import { Input } from "../components/ui/input";
 import { Button } from "../components/ui/button";
 import { VibrantAuroraBackground } from "../components/vibrant-aurora-background";
 import { checkServerHealth, setServerUrl } from "../actions";
+import { StoreLoginPreferences } from "../actions/store/store-login-preferences";
 import { Loader2, Server, CheckCircle, Globe, Shield } from "lucide-react";
 import axios from "axios";
 
@@ -38,10 +39,23 @@ export function ServerSetup({ onNext }: ServerSetupProps) {
   useEffect(() => {
     async function fetchConfig() {
       try {
+        // 1. Try runtime config (Docker / env-based default)
         const { data } = await axios("/api/config");
-        if (data.defaultServerUrl) setUrl(data.defaultServerUrl);
+        if (data.defaultServerUrl) {
+          setUrl(data.defaultServerUrl);
+          return;
+        }
       } catch (err) {
         console.error("Failed to fetch runtime config", err);
+      }
+
+      try {
+        // 2. Fall back to saved login preferences so returning users see the
+        // server URL they previously connected to.
+        const prefs = await StoreLoginPreferences.get();
+        if (prefs?.serverUrl) setUrl(prefs.serverUrl);
+      } catch (err) {
+        console.error("Failed to read login preferences", err);
       } finally {
         setUrlLoading(false);
       }

--- a/src/components/settings/seerr-section.tsx
+++ b/src/components/settings/seerr-section.tsx
@@ -33,6 +33,7 @@ import {
   TabsTrigger,
 } from "@/src/components/ui/tabs";
 import { StoreSeerrData } from "@/src/actions/store/store-seerr-data";
+import { StoreLoginPreferences } from "@/src/actions/store/store-login-preferences";
 import { type SeerrAuthType } from "@/src/actions/store/server-actions";
 import { toast } from "sonner";
 import { testSeerrConnection } from "@/src/actions";
@@ -75,21 +76,27 @@ export default function SeerrSection() {
     loadSettings();
   }, [loadSettings]);
 
+  const getRememberMePreference = useCallback(async () => {
+    const prefs = await StoreLoginPreferences.get();
+    return prefs?.rememberMe === true;
+  }, []);
+
   const handleSave = async () => {
     try {
+      const rememberMe = await getRememberMePreference();
       if (authType === "api-key") {
         await StoreSeerrData.set({
           authType: "api-key",
           serverUrl,
           apiKey,
-        });
+        }, { persistent: rememberMe });
       } else {
         await StoreSeerrData.set({
           authType,
           serverUrl,
           username,
           password,
-        });
+        }, { persistent: rememberMe });
       }
       toast.success("Seerr settings saved successfully");
     } catch (error) {


### PR DESCRIPTION
Closes #73 
### <ins>High level overview from user's pov</ins>

| Area | Before | After |
|---|---|---|
| **Session persistence** | Always session-scoped (cleared when browser closes) | User-controlled via "Keep me signed in on this device" checkbox |
| **Login form** | Username + password only | Adds "Keep me signed in" checkbox on both password and Quick Connect tabs |
| **Session duration (remembered)** | — | Cookies persist for 1 year; TTL slides forward on every visit |
| **Session duration (not remembered)** | — | Expires after 8 hours of inactivity, even if browser restores the tab |
| **Server URL pre-fill** | Pre-filled only if a Docker/env default was configured | Pre-filled from last-used server URL for all returning users |
| **Logout** | Clears cookies locally only | Also revokes the token on the Jellyfin server, ending the server-side session |
| **Server URL on logout/expiry** | Cleared along with auth data | Preserved so the server field is pre-filled on next login |
| **Seerr config persistence** | Always session-scoped | Matches the user's "Keep me signed in" preference |


### <ins>Changes</ins>

#### Remember Me

- Added a **"Keep me signed in on this device"** checkbox to both the password and Quick Connect tabs in the login form.
- The defaults is set to `true` and is persisted in the login-preferences cookie so it's restored on the next visit.

#### Cookie Session Management

- **Persistent sessions** (`rememberMe = true`): auth, server URL, and Seerr cookies are written with a **1-year** `maxAge`.
- **Session-scoped sessions** (`rememberMe = false`): cookies carry no `maxAge` (browser-session lifetime) plus an `expiresAt` timestamp embedded in the auth payload for an **8-hour idle-expiry window**. Even if the browser restores the session cookie (e.g. Chrome "Continue where you left off"), the session is treated as expired after 8 hours of inactivity.
- Login-preferences cookie is always persistent (**10-year** TTL) since it contains no secrets.

#### Sliding TTL Refresh

- Added `refreshAuthCookieTTL()` server action called in `MainLayout`, once immediately on mount, then every hour via setInterval (cleared on unmount).
  - **Remembered users**: slides the 1-year TTL forward and clears any stale `expiresAt`.
  - **Non-remembered users**: slides the 8-hour idle window forward so active users aren't kicked out mid-session.

#### Logout

- `logout()` converted to `async` and now calls `POST /Sessions/Logout` on the Jellyfin server before clearing cookies, keeping Jellyfin's session list clean.

#### Server Setup UX

- The server setup screen now falls back to the saved login-preferences cookie to pre-fill the server URL for returning users when no Docker/env default is configured.

#### Seerr Settings

- Seerr auth data cookie lifetime is now aligned with the user's `rememberMe` preference.